### PR TITLE
Add constructor to Fragment

### DIFF
--- a/src/main/java/com/rjrudin/marklogic/junit/Fragment.java
+++ b/src/main/java/com/rjrudin/marklogic/junit/Fragment.java
@@ -28,6 +28,10 @@ public class Fragment extends Assert {
     private Namespace[] namespaces;
     private String uri;
 
+    public Fragment(Document doc) {
+    	this.internalDoc = doc;
+    }
+    
     public Fragment(String xml, Namespace... namespaces) {
         try {
             internalDoc = new SAXBuilder().build(new StringReader(xml));


### PR DESCRIPTION
The MarkLogic Java API allows a JDOMHandle to be created.  I think it would be useful to add this constructor.
